### PR TITLE
refactor(gsutil): Migrate gsutil to gcloud storage

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -178,4 +178,3 @@ N/A
 | TAA-354  | [Jenkins] CVD adb devices not always working as expected                                 |
 
 ***
-

--- a/terraform/modules/sdv-copy-to-bastion-host/main.tf
+++ b/terraform/modules/sdv-copy-to-bastion-host/main.tf
@@ -45,7 +45,7 @@ resource "null_resource" "copy_from_storage_to_bastion_host" {
       # Create all the directories defined by the filename
       mkdir -p ${var.destination_directory}
 
-      gsutil cp gs://${var.bucket_name}/${var.bucket_destination_path} ${var.destination_directory}/${var.destination_filename}
+      gcloud storage cp gs://${var.bucket_name}/${var.bucket_destination_path} ${var.destination_directory}/${var.destination_filename}
     "
     EOT
   }


### PR DESCRIPTION
Automated: Migrate paths from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface. `gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](https://github.com/GoogleCloudPlatform/gsutil/blob/master/GCLOUD-MIGRATION.md).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration