### PR TITLE
Add Squish Custom Image for Cloud Workstations

### DIFF
--- a/apps/workstations/squish/.dockerignore
+++ b/apps/workstations/squish/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/apps/workstations/squish/Dockerfile
+++ b/apps/workstations/squish/Dockerfile
@@ -1,0 +1,39 @@
+# syntax=docker/dockerfile:1.4
+
+# Copyright (C) 2026 The Qt Company Ltd.
+# All rights reserved.
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+# This image layers the Squish application onto the GNOME foundation.
+
+# The BASE_IMAGE is resolved by Skaffold.
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE}
+
+ARG CURL_OPTS="-fsSL --retry 3"
+ARG EXTRA_PKGS="\
+  libxcb-icccm4 \
+  libxcb-image0 \
+  libxcb-keysyms1 \
+  libxcb-render-util0 \
+  libxcb-xinerama0 \
+  libxcb-xkb1 \
+  libxkbcommon-x11-0"
+ARG SQUISH_DOWNLOAD_URL="https://d13lb3tujbc8s0.cloudfront.net/squish/squish-9.2.2-android-linux64.run"
+ARG SQUISH_GCP_LICENSE_SECRET
+ARG SQUISH_SHA256="202758cf795b6cae939d5ba714fd1d31c83478746f0fb1b2ea33ca3881e7669d"
+
+ENV CURL_OPTS="${CURL_OPTS}"
+ENV EXTRA_PKGS="${EXTRA_PKGS}"
+ENV SQUISH_DOWNLOAD_URL="${SQUISH_DOWNLOAD_URL}"
+ENV SQUISH_GCP_LICENSE_SECRET="${SQUISH_GCP_LICENSE_SECRET}"
+ENV SQUISH_SHA256="${SQUISH_SHA256}"
+
+# Merge assets into the container
+COPY assets/ /
+
+# Perform centralized workstation configuration (hooks, packages, and integration).
+RUN /google/scripts/build/configure_workstation.sh

--- a/apps/workstations/squish/README.md
+++ b/apps/workstations/squish/README.md
@@ -1,0 +1,135 @@
+<!--
+Copyright 2026 Google LLC
+
+Copyright (C) 2026 The Qt Company Ltd.
+All rights reserved.
+
+This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+-->
+
+# Squish Custom Image for Cloud Workstations
+
+The [CICD-Foundation](https://github.com/GoogleCloudPlatform/cicd-foundation)
+[Blueprint for Cloud Workstations](https://github.com/GoogleCloudPlatform/cicd-foundation/tree/main/infra/blueprints/workstations)
+automates the deployment of
+[Cloud Workstations](https://docs.cloud.google.com/workstations/docs/overview)
+using this custom image example for [Squish](https://www.qt.io/quality-assurance/squish).
+It is designed for a self-service model where developers and testers can create their own
+Cloud Workstation instances.
+
+The **Squish Custom Image for Cloud Workstations** is a specialized image layer built on top of the [GNOME Workstation Blueprint](../gnome/README.md). It is designed to provide a highly productive, pre-configured desktop environment for Google Cloud Workstations, specifically tailored for advanced testing.
+
+## 🚀 Key Features
+
+- **Foundation-First**: Seamlessly integrates with the [cicd-foundation](https://github.com/GoogleCloudPlatform/cicd-foundation) workstations blueprint.
+- **Headless Excellence**: Leverages the base blueprint's headless Wayland and RDP/Guacamole stack for low-latency browser-based access.
+- **Testing-Ready**: Includes the professional automated GUI testing framework for testing GUI apps.
+
+## 🏗️ Architecture
+
+This image uses a **multi-layered build strategy**:
+
+1.  **Base Layer**: [GNOME Workstation](../gnome/Dockerfile) - Handles the core OS (Ubuntu 24.04), systemd, GNOME Shell 46, and remote access protocols.
+2.  **Squish Layer**: [Dockerfile](./Dockerfile) - Injects specialized post-build-time hooks (e.g., `01_install_squish.sh`), custom assets, and tools to layer on top of the foundation.
+
+## 🛠️ Build Arguments
+
+This image supports and propagates all base arguments, including:
+
+| Argument                    | Default               | Description                                      |
+| :-------------------------- | :-------------------- | :----------------------------------------------- |
+| `SQUISH_GCP_LICENSE_SECRET` | `squish-license-key`  | Name of the GCP Secret Manager secret used to retrieve the Squish license during image build. |
+
+## 📖 Documentation
+
+- **[Design Document](./docs/design.md)**: Deep-dive into the thin-layer architecture, hook-based integration logic, and declarative packaging.
+- **[System Overview](../../../docs/system_overview.md)**: High-level map of the entire Cloud Workstations Custom Image blueprint stack.
+- **[Base Blueprint Docs](../gnome/docs/design.md)**: Deep-dives into the underlying systemd orchestrations and networking handover logic.
+- **[Squish Doc](https://doc.qt.io/squish/)**: Official reference documentation for the Squish GUI test automation tool.
+
+## 🔒 Secret manager
+You can use GCP Secret Manager to supply the Squish license. By default, the secret is expected under the name `squish-license-key`, which is configured via the `SQUISH_GCP_LICENSE_SECRET` build argument. The secret value is fetched during the image build.
+
+Make sure the following service accounts used during the build have been granted the Secret Manager Secret Accessor role (read permission) on this secret — otherwise the build will fail to retrieve the license:
+
+- `cloudbuild@<PROJECT_ID>.iam.gserviceaccount.com`
+- `workstations@<PROJECT_ID>.iam.gserviceaccount.com`
+
+(where `<PROJECT_ID>` is your GCP project ID)
+
+## Getting Started
+
+1.  **Clone the CICD-Foundation**:
+    ```bash
+    git clone https://github.com/GoogleCloudPlatform/cicd-foundation.git
+    cd cicd-foundation/infra/blueprints/workstations
+    ```
+2.  **Configure**: Create a `terraform.tfvars` file such as:
+
+    ```yml
+    project_id = "YOUR_GCP_PROJECT_ID"
+
+    # Squish Custom Image Build
+    cws_custom_images = {
+      "squish" : {
+        git_repo = {
+          url    = "https://github.com/GoogleCloudPlatform/cicd-foundation.git"
+          branch = "main"
+        }
+        build = {
+          skaffold_path = "apps/workstations/squish/"
+          machine_type  = "E2_HIGHCPU_32"
+          # Pass environment variables to Skaffold to configure the Preflight UI source, Base Image or Squish license
+          env = {
+            CWS_BASE_IMAGE_TAG = "latest"
+            GCP_REGION         = "us-central1"
+            PREFLIGHT_WEB_REPO = "https://github.com/GoogleCloudPlatform/cicd-foundation.git"
+            PREFLIGHT_WEB_DIR  = "apps/workstations/preflight-web"
+            # Name of the GCP Secret Manager secret containing the Squish license. Fetched at build time.
+            # SQUISH_GCP_LICENSE_SECRET = "squish-license-key"
+          }
+        }
+      }
+    }
+
+    # Workstation Cluster
+    cws_clusters = {
+      "workstations" = {
+        network    = "workstations"
+        region     = "us-central1"
+        subnetwork = "primary"
+      }
+    }
+
+    # Workstation Configuration
+    cws_configs = {
+      "custom" = {
+        cws_cluster = "workstations"
+
+        # Self-service: Grant permissions to a group or specific users to create their own instances
+        #creators = ["group:developers@example.com"]
+
+        # Reference the custom image defined above
+        custom_image_names = ["squish"]
+
+        # Best user experience: Keep >0 instance(s) ready in the pool for instant startup
+        pool_size = 1
+
+        # Hardware Specs
+        machine_type                 = "e2-standard-8"
+        enable_nested_virtualization = false
+        persistent_disk_size_gb      = 500
+        persistent_disk_type         = "pd-balanced"
+      }
+    }
+    ```
+
+3.  **Deploy**:
+    ```bash
+    terraform init
+    terraform plan
+    terraform apply
+    ```
+
+For more information have a look at the **[Infrastructure & Deployment Guide](../docs/deployment_guide.md)**.

--- a/apps/workstations/squish/assets/etc/workstation-startup.d/200_setting-squish.sh
+++ b/apps/workstations/squish/assets/etc/workstation-startup.d/200_setting-squish.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright (C) 2026 The Qt Company Ltd.
+# All rights reserved.
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+set -euo pipefail
+
+source "/google/scripts/common.sh"
+
+_HOME_DIR="/home/${WORKSTATION_USER}"
+_QT_DIR="/opt/qt"
+_SQUISH_DIR="${_QT_DIR}/squish"
+_SQUISH_GCP_LICENSE_SECRET_NAME=".squish-gcp-license-secret"
+_SQUISH_LICENSE_NAME=".squish-license"
+
+squish_fetch_license_key() {
+  SQUISH_GCP_LICENSE_SECRET=$(
+    cat "${_QT_DIR}/${_SQUISH_GCP_LICENSE_SECRET_NAME}"
+  )
+  SQUISH_LICENSE_KEY=$(
+    gcloud \
+      secrets \
+      versions \
+      access \
+      latest \
+      --secret=${SQUISH_GCP_LICENSE_SECRET}
+  )
+  jq \
+    -n \
+    --arg key "${SQUISH_LICENSE_KEY}" \
+    '{format: "local", key: $key}' \
+    > "${_HOME_DIR}/${_SQUISH_LICENSE_NAME}"
+}
+
+squish_make_symlink() {
+    ln -s "${_SQUISH_DIR}" "${_HOME_DIR}"
+}
+
+main() {
+  echo "Setting Squish..."
+  squish_fetch_license_key
+  squish_make_symlink
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/apps/workstations/squish/assets/post-install-hooks.d/01_install_squish.sh
+++ b/apps/workstations/squish/assets/post-install-hooks.d/01_install_squish.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Copyright (C) 2026 The Qt Company Ltd.
+# All rights reserved.
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+set -euo pipefail
+
+source "/google/scripts/common.sh"
+source "/google/scripts/fetch_assets.sh"
+
+# Define variables
+CURL_OPTS="${CURL_OPTS}"
+SQUISH_DOWNLOAD_URL="${SQUISH_DOWNLOAD_URL}"
+SQUISH_GCP_LICENSE_SECRET="${SQUISH_GCP_LICENSE_SECRET}"
+SQUISH_SHA256="${SQUISH_SHA256}"
+
+_INSTALLER_NAME="squish-android-linux64.run"
+_LICENSE_KEY_PATH="/tmp/squish-license-key"
+_QT_DIR="/opt/qt"
+_SQUISH_GCP_LICENSE_SECRET_NAME=".squish-gcp-license-secret"
+_SQUISH_TARGET_DIR="${_QT_DIR}/squish"
+
+
+fetch_installer() {
+  log "Fetching Squish installer..."
+  download_and_validate "${SQUISH_DOWNLOAD_URL}" "${SQUISH_SHA256}" "${_INSTALLER_NAME}"
+  chmod +x "${_INSTALLER_NAME}"
+}
+
+
+fetch_license_key() {
+  log "Fetching license key from GCP Secret Manager (secret: ${SQUISH_GCP_LICENSE_SECRET})..."
+  gcloud \
+    secrets \
+    versions \
+    access \
+    latest \
+    --secret=${SQUISH_GCP_LICENSE_SECRET} \
+    > "${_LICENSE_KEY_PATH}"
+  mkdir -p "${_QT_DIR}"
+  printf "%s" \
+    "${SQUISH_GCP_LICENSE_SECRET}" \
+    > "${_QT_DIR}/${_SQUISH_GCP_LICENSE_SECRET_NAME}"
+}
+
+
+install() {
+  log "Running Squish installer..."
+  mkdir -p "${_SQUISH_TARGET_DIR}"
+  ./${_INSTALLER_NAME} \
+      unattended=1 \
+      targetdir="${_SQUISH_TARGET_DIR}" \
+      licensekey="$(cat ${_LICENSE_KEY_PATH})"
+}
+
+
+cleanup() {
+  log "Removing license key..."
+  rm "${_LICENSE_KEY_PATH}"
+  rm "${_INSTALLER_NAME}"
+}
+
+
+main() {
+  log "Begin Squish installation..."
+  fetch_installer
+  fetch_license_key
+  install
+  cleanup
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/apps/workstations/squish/skaffold.yaml
+++ b/apps/workstations/squish/skaffold.yaml
@@ -1,0 +1,27 @@
+# Copyright (C) 2026 The Qt Company Ltd.
+# All rights reserved.
+#
+# This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+# WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+apiVersion: skaffold/v3
+kind: Config
+metadata:
+  name: squish
+requires:
+  - path: ../gnome/skaffold.yaml
+build:
+  artifacts:
+    - image: squish
+      context: .
+      docker:
+        network: cloudbuild
+        buildArgs:
+          CWS_BASE_IMAGE_TAG: '{{.CWS_BASE_IMAGE_TAG | default "latest"}}'
+          GCP_REGION: '{{.GCP_REGION | default "us-central1"}}'
+          PREFLIGHT_WEB_REPO: '{{.PREFLIGHT_WEB_REPO | default ""}}'
+          PREFLIGHT_WEB_DIR: '{{.PREFLIGHT_WEB_DIR | default ""}}'
+          SQUISH_GCP_LICENSE_SECRET: '{{.SQUISH_GCP_LICENSE_SECRET | default "squish-license-key"}}'
+      requires:
+        - image: gnome
+          alias: BASE_IMAGE


### PR DESCRIPTION
This change adds a cloudworkstation for Squish.

The change and scope is nearly the same as it is for custom image for Cloud Workstations.
For more information how Squish is used and how to set up tests for Android please have a look at the [official documentation](https://doc.qt.io/squish/squish-for-android-tutorials.html).

For testing purposes the license key for Squish can be requested from The Qt Group (please see attached README for more information).